### PR TITLE
Update delete operation to refresh scheduler

### DIFF
--- a/main.py
+++ b/main.py
@@ -408,7 +408,9 @@ class RssPlugin(Star):
             yield event.plain_result("索引越界")
             return
         else:
-            # 刷新定时任务            self._fresh_asyncIOScheduler()            self.data_handler.data["rsshub_endpoints"].pop(idx)
+            # 刷新定时任务
+            self._fresh_asyncIOScheduler()
+            self.data_handler.data["rsshub_endpoints"].pop(idx)            
             self.data_handler.save_data()
             yield event.plain_result("删除成功")
 

--- a/main.py
+++ b/main.py
@@ -408,9 +408,7 @@ class RssPlugin(Star):
             yield event.plain_result("索引越界")
             return
         else:
-            # TODO:删除对应的定时任务
-            self.scheduler.remove_job()
-            self.data_handler.data["rsshub_endpoints"].pop(idx)
+            # 刷新定时任务            self._fresh_asyncIOScheduler()            self.data_handler.data["rsshub_endpoints"].pop(idx)
             self.data_handler.save_data()
             yield event.plain_result("删除成功")
 


### PR DESCRIPTION
## Bug Fix: Fix remove_job() missing job_id parameter

### Issue
When executing `/rss rsshub remove <idx>` command, the following error occurs:
```
BaseScheduler.remove_job() missing 1 required positional argument: 'job_id'
```

### Root Cause
In the `rsshub_remove` function (line 412), `self.scheduler.remove_job()` was called without the required `job_id` parameter.

### Solution
Replaced the incorrect `remove_job()` call with `self._fresh_asyncIOScheduler()`, which is the same approach used in the `remove_command` function. This method refreshes all scheduled tasks after removing the endpoint from the data store.

### Changes
- Removed: `self.scheduler.remove_job()`
- Added: `self._fresh_asyncIOScheduler()`
- Updated comment for clarity